### PR TITLE
Resolving "add replicas - emergency push" back into dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - proxy
     image: sc-registry.fredhutch.org/shiny-cromwell:latest
     deploy:
+      replicas: 4
       restart_policy:
         condition: on-failure
       labels:


### PR DESCRIPTION
Just merging back Dan's recent commit to main increasing the number of replicas. Seems to be working fine in production, so no testing necessary.