### PR TITLE
Add labels to runs table and move to left

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard
 
 RUN R -q -e "remotes::install_github('getwilds/proofr@v0.2')"
 
-RUN R -q -e "remotes::install_github('getwilds/rcromwell@dev')"
+RUN R -q -e "remotes::install_github('getwilds/rcromwell@v3.2.5')"
 
 RUN rm -rf /srv/shiny-server/
 COPY app/ /srv/shiny-server/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard
 
 RUN R -q -e "remotes::install_github('getwilds/proofr@v0.2')"
 
-RUN R -q -e "remotes::install_github('getwilds/rcromwell@v3.2.1')"
+RUN R -q -e "remotes::install_github('getwilds/rcromwell@dev')"
 
 RUN rm -rf /srv/shiny-server/
 COPY app/ /srv/shiny-server/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 RSCRIPT = Rscript --no-init-file
 FILE_TARGET := "${FILE}"
-DEPS := $(shell ${RSCRIPT} -e 'invisible(lapply(c("glue", "cli"), require, character.only = TRUE, quiet = TRUE))' -e 'deps = renv::dependencies(quiet = TRUE)' -e 'uniq_pkgs = sort(unique(deps$$Package))' -e 'uniq_pkgs = uniq_pkgs[!grepl("^proofr$$|^rcromwell$$", uniq_pkgs)]' -e 'cat(c("getwilds/proofr@v0.2", "getwilds/rcromwell@dev", uniq_pkgs), file="deps.txt", sep="\n")')
+DEPS := $(shell ${RSCRIPT} -e 'invisible(lapply(c("glue", "cli"), require, character.only = TRUE, quiet = TRUE))' -e 'deps = renv::dependencies(quiet = TRUE)' -e 'uniq_pkgs = sort(unique(deps$$Package))' -e 'uniq_pkgs = uniq_pkgs[!grepl("^proofr$$|^rcromwell$$", uniq_pkgs)]' -e 'cat(c("getwilds/proofr@v0.2", "getwilds/rcromwell@v3.2.5", uniq_pkgs), file="deps.txt", sep="\n")')
 
 run:
 	${RSCRIPT} -e "options(shiny.autoreload = TRUE)" \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 RSCRIPT = Rscript --no-init-file
 FILE_TARGET := "${FILE}"
-DEPS := $(shell ${RSCRIPT} -e 'invisible(lapply(c("glue", "cli"), require, character.only = TRUE, quiet = TRUE))' -e 'deps = renv::dependencies(quiet = TRUE)' -e 'uniq_pkgs = sort(unique(deps$$Package))' -e 'uniq_pkgs = uniq_pkgs[!grepl("^proofr$$|^rcromwell$$", uniq_pkgs)]' -e 'cat(c("getwilds/proofr@v0.2", "getwilds/rcromwell@v3.2.1", uniq_pkgs), file="deps.txt", sep="\n")')
+DEPS := $(shell ${RSCRIPT} -e 'invisible(lapply(c("glue", "cli"), require, character.only = TRUE, quiet = TRUE))' -e 'deps = renv::dependencies(quiet = TRUE)' -e 'uniq_pkgs = sort(unique(deps$$Package))' -e 'uniq_pkgs = uniq_pkgs[!grepl("^proofr$$|^rcromwell$$", uniq_pkgs)]' -e 'cat(c("getwilds/proofr@v0.2", "getwilds/rcromwell@dev", uniq_pkgs), file="deps.txt", sep="\n")')
 
 run:
 	${RSCRIPT} -e "options(shiny.autoreload = TRUE)" \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can run this Shiny app locally. First you'll need to install required packag
 (note: run `make pkg_deps_cmd` to update the below code block)
 
 ```r
-pak::pak(c("getwilds/proofr@v0.2", "getwilds/rcromwell@v3.2.1", "dplyr", "DT", "ggplot2", "glue", "httr", "jsonlite", "lubridate", "magrittr", "memoise", "purrr", "rclipboard", "RColorBrewer", "rlang", "shiny", "shinyBS", "shinydashboard", "shinydashboardPlus", "shinyFeedback", "shinyjs", "shinylogs", "shinyvalidate", "shinyWidgets", "testthat", "tibble", "uuid"))
+pak::pak(c("getwilds/proofr@v0.2", "getwilds/rcromwell@v3.2.5", "dplyr", "DT", "ggplot2", "glue", "httr", "jsonlite", "lubridate", "magrittr", "memoise", "purrr", "rclipboard", "RColorBrewer", "rlang", "shiny", "shinyBS", "shinydashboard", "shinydashboardPlus", "shinyFeedback", "shinyjs", "shinylogs", "shinyvalidate", "shinyWidgets", "testthat", "tibble", "uuid"))
 ```
 
 And the above yourself in R. 

--- a/app/server.R
+++ b/app/server.R
@@ -545,7 +545,8 @@ server <- function(input, output, session) {
           labels_df <- lapply(workflowDat$workflow_id, \(x) {
             as_tibble_row(cromwell_labels(x, url = rv$url, token = rv$token)) %>%
               mutate(workflow_id = sub("cromwell-", "", workflow_id))
-          }) %>% bind_rows()
+          }) %>%
+            bind_rows()
           workflowDat <- left_join(workflowDat, labels_df, by = "workflow_id")
           ## Then reorder columns
           workflowDat <- dplyr::relocate(workflowDat, copyId, .after = workflow_id)

--- a/app/server.R
+++ b/app/server.R
@@ -540,8 +540,17 @@ server <- function(input, output, session) {
             )
           )
 
-          # reorder columns
+          # Add workflow labels
+          ## Get labels data
+          labels_df <- lapply(workflowDat$workflow_id, \(x) {
+            as_tibble_row(cromwell_labels(x, url = rv$url, token = rv$token)) %>%
+              mutate(workflow_id = sub("cromwell-", "", workflow_id))
+          }) %>% bind_rows()
+          workflowDat <- left_join(workflowDat, labels_df, by = "workflow_id")
+          ## Then reorder columns
           workflowDat <- dplyr::relocate(workflowDat, copyId, .after = workflow_id)
+          workflowDat <- dplyr::relocate(workflowDat, Label, .after = copyId)
+          workflowDat <- dplyr::relocate(workflowDat, secondaryLabel, .after = Label)
         }
       } else {
         workflowDat <- data.frame(


### PR DESCRIPTION
fixes #106 
see also getwilds/rcromwell#43

## Before 

<img width="1019" alt="Screenshot 2024-07-26 at 3 07 46 PM" src="https://github.com/user-attachments/assets/603b8868-3a1c-46d2-99a3-d023c62f0c78">

## After

<img width="983" alt="Screenshot 2024-07-26 at 3 07 40 PM" src="https://github.com/user-attachments/assets/06cf433b-4225-4043-9e06-a0b04ed6bcc2">

----

The labels are in the workflow description table, and left unchanged - they're far over on the right - let me know if you want those shifted left too

This requires the version of `rcromwell` on the `dev` branch as there's a new function needed that fetches workflow labels