### PR TITLE
Possible option to view inputs and fix a bug

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,11 +16,6 @@ stages:
   - build
   - test
   - deploy
-
-stages:
-  - build
-  - test
-  - deploy
   
 build:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,16 @@ test:
     docker run -w /srv/shiny-server --rm sc-registry.fredhutch.org/shiny-cromwell:test R -q -e 'testthat::test_dir("tests")'
 
 
+deploy_review_image:
+  stage: deploy
+  except:
+    refs:
+      - main
+      - dev
+  script:
+    - docker tag sc-registry.fredhutch.org/shiny-cromwell:test nexus-registry.fredhutch.org/scicomp-nexus/${CI_PROJECT_NAME}:${CI_COMMIT_BRANCH}
+    - docker push nexus-registry.fredhutch.org/scicomp-nexus/${CI_PROJECT_NAME}:${CI_COMMIT_BRANCH}
+
 deploy_preview:
   stage: deploy
   only:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN R -q -e "remotes::install_github('getwilds/proofr@v0.2')"
 
 RUN R -q -e "remotes::install_github('getwilds/rcromwell@v3.2.1')"
 
+RUN R -q -e "remotes::install_github('timelyportfolio/reactR')"
+
 RUN rm -rf /srv/shiny-server/
 COPY app/ /srv/shiny-server/
 # COPY ./shiny-server.conf /etc/shiny-server/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && apt-get install -y libssh-dev
 
 RUN R -q -e 'install.packages(c("ellipsis"), repos="https://cran.rstudio.com/")'
 RUN R -q -e 'install.packages(c("shiny"), repos="https://cran.rstudio.com/")'
-RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard", "shinydashboardPlus", "ssh", "remotes", "markdown", "lubridate", "jsonlite", "dplyr", "DT", "glue", "httr", "purrr", "RColorBrewer", "rlang", "shinyBS", "shinyjs", "tidyverse", "uuid", "memoise", "rclipboard", "shinyvalidate", "shinylogs", "testhat"), repos="https://cran.r-project.org")'
+RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard", "shinydashboardPlus", "ssh", "remotes", "markdown", "lubridate", "jsonlite", "dplyr", "DT", "glue", "httr", "purrr", "RColorBrewer", "rlang", "shinyBS", "shinyjs", "tidyverse", "uuid", "memoise", "rclipboard", "shinyvalidate", "shinylogs", "testhat", "listviewer"), repos="https://cran.r-project.org")'
 
 RUN R -q -e "remotes::install_github('getwilds/proofr@v0.2')"
 

--- a/app/server.R
+++ b/app/server.R
@@ -28,6 +28,8 @@ library(rcromwell)
 
 library(rclipboard)
 
+library(listviewer)
+
 source("sidebar.R")
 source("modals.R")
 source("proof.R")
@@ -716,20 +718,39 @@ server <- function(input, output, session) {
   workflowInputs <- eventReactive(input$joblistCromwell_rows_selected, {
     print("find inputs")
     data <- workflowUpdate()
+
     FOCUS_ID <- data[input$joblistCromwell_rows_selected, ]$workflow_id
-    as.data.frame(jsonlite::fromJSON(
-      cromwell_workflow(FOCUS_ID,
-        url = rv$url,
-        token = rv$token
-      )$inputs
-    ))
+    output$currentWorkflowId <- renderText({
+      paste("Workflow ID: ", FOCUS_ID)
+    })
+
+    cromwell_workflow(FOCUS_ID,
+      url = rv$url,
+      token = rv$token
+    )$inputs
   })
-  output$workflowInp <- renderDT(
-    data <- workflowInputs(),
-    class = "compact",
-    filter = "top",
-    options = list(scrollX = TRUE), selection = "single", rownames = FALSE
-  )
+  ### inputs json javascript viewer
+  output$workflowInp <- renderReactjson({
+    reactjson(workflowInputs())
+  })
+  ### edit json viewer
+  observeEvent(input$workflowInp_edit, {
+    str(input$workflowInp_edit, max.level=2)
+  })
+  ### go to viewer tab when clicked from Tracking tab
+  observeEvent(input$linkToViewerTab, {
+    updateTabItems(session, "tabs", "viewer")
+  })
+  ### go back to tracking tab from viewer tab
+  observeEvent(input$linkToTrackingTab, {
+    updateTabsetPanel(session, "tabs", "tracking")
+  })
+  ### set workflow id display in viewer tab back to none
+  ### when nothing selected in the Workflows Run table
+  observeEvent(input$joblistCromwell_rows_selected, {
+    output$currentWorkflowId <- renderText({"Workflow ID: "})
+  }, ignoreNULL = FALSE)
+
   ## Render a list of jobs in a table for a workflow
   output$joblistCromwell <- renderDT({
     datatable(

--- a/app/sidebar.R
+++ b/app/sidebar.R
@@ -23,6 +23,10 @@ menu_item_trouble <- menuItem("Troubleshoot",
   tabName = "troubleshoot", icon = icon("wrench"),
   badgeLabel = "troubleshoot", badgeColor = "red"
 )
+menu_item_viewer <- menuItem("Viewer",
+  tabName = "viewer", icon = icon("wrench"),
+  badgeLabel = "viewer", badgeColor = "purple"
+)
 
 proofSidebar <- function() {
   sidebarMenu(
@@ -32,7 +36,8 @@ proofSidebar <- function() {
     menu_item_validate,
     menu_item_submit,
     menu_item_track,
-    menu_item_trouble
+    menu_item_trouble,
+    menu_item_viewer
   )
 }
 
@@ -43,6 +48,7 @@ nonProofSidebar <- function() {
     menu_item_validate,
     menu_item_submit,
     menu_item_track,
-    menu_item_trouble
+    menu_item_trouble,
+    menu_item_viewer
   )
 }

--- a/app/tab-tracking.R
+++ b/app/tab-tracking.R
@@ -89,7 +89,7 @@ tab_tracking <- tabItem(
     box(
       width = 6,
       title = "Workflow Inputs",
-      DTOutput("workflowInp")
+      actionButton("linkToViewerTab", "View list")
     )
   ),
   fluidRow(

--- a/app/tab-viewer.R
+++ b/app/tab-viewer.R
@@ -1,0 +1,16 @@
+library(listviewer)
+
+tab_viewer <- tabItem(
+  tabName = "viewer",
+  fluidRow(
+    box(
+      title = "View Workflow Inputs",
+      width = 12,
+      textOutput("currentWorkflowId"),
+      p(""),
+      actionButton("linkToTrackingTab", "Back to Track Jobs Tab"),
+      p(""),
+      reactjsonOutput("workflowInp", height = "100%")
+    )
+  )
+)

--- a/app/ui.R
+++ b/app/ui.R
@@ -20,6 +20,7 @@ source("tab-validate.R")
 source("tab-submission.R")
 source("tab-tracking.R")
 source("tab-troubleshoot.R")
+source("tab-viewer.R")
 source("sidebar.R")
 
 ui <- dashboardPage(
@@ -52,7 +53,8 @@ ui <- dashboardPage(
       tab_validate,
       tab_submission,
       tab_tracking,
-      tab_troublehsoot
+      tab_troublehsoot,
+      tab_viewer
     )
   )
 )


### PR DESCRIPTION
fixes #85 

This approach uses `listviewer` pkg suggested by Dan. 

It's just unwieldy to view a nested structure like JSON or an R list in a small window within a web page (e.g, if we tried to use the same window in the tracking tab where the current inputs table lives), so I went with a whole new page for viewing the inputs structure. 

Run locally, and/or have a look at the below gif

![stuff3](https://github.com/user-attachments/assets/b289f06c-170e-4c88-8800-a8f4b398c3c5)

Thoughts?

Alternatives:
- just a download button to download the json
- some other solution, there doesn't appear to be obvious alternatives to `listviewer`
- when we move to proof 2 in JS land we'll have other options but that's down the road