### PR TITLE
add capability to convert wdl to mermaid

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ build:
   script: |
     python3 build_helper.py docker-compose.yml --fluentd-logging > /dev/null
     echo $DB_CONFIG | base64 -d > .my.cnf
-    docker build --no-cache \
+    docker build \
       -t sc-registry.fredhutch.org/shiny-cromwell:test \
       --build-arg CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH} \
       --build-arg CI_COMMIT_SHA=${CI_COMMIT_SHA} \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,9 @@ variables:
 before_script:
   - apk update
   - apk --no-cache add py3-pip python3 curl
-  - pip3 install pyyaml --break-system-packages
+  - python3 -m venv $HOME/.venv
+  - export PATH=$HOME/.venv/bin:$PATH
+  - pip3 install pyyaml
   - curl -O https://raw.githubusercontent.com/FredHutch/swarm-build-helper/main/build_helper.py 
   # below is from https://stackoverflow.com/a/65810302/470769
   - mkdir -p $HOME/.docker
@@ -27,7 +29,7 @@ build:
   script: |
     python3 build_helper.py docker-compose.yml --fluentd-logging > /dev/null
     echo $DB_CONFIG | base64 -d > .my.cnf
-    docker build \
+    docker build --no-cache \
       -t sc-registry.fredhutch.org/shiny-cromwell:test \
       --build-arg CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH} \
       --build-arg CI_COMMIT_SHA=${CI_COMMIT_SHA} \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ build:
   script: |
     python3 build_helper.py docker-compose.yml --fluentd-logging > /dev/null
     echo $DB_CONFIG | base64 -d > .my.cnf
-    docker build \
+    docker build --no-cache \
       -t sc-registry.fredhutch.org/shiny-cromwell:test \
       --build-arg CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH} \
       --build-arg CI_COMMIT_SHA=${CI_COMMIT_SHA} \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,15 @@ test:
     curl -sI http://shiny-cromwell:3838 | head -1 | grep -q "200 OK"
     docker run -w /srv/shiny-server --rm sc-registry.fredhutch.org/shiny-cromwell:test R -q -e 'testthat::test_dir("tests")'
 
+deploy_review_image:
+  stage: deploy
+  except:
+    refs:
+      - main
+      - dev
+  script:
+    - docker tag sc-registry.fredhutch.org/shiny-cromwell:test nexus-registry.fredhutch.org/scicomp-nexus/${CI_PROJECT_NAME}:${CI_COMMIT_BRANCH}
+    - docker push nexus-registry.fredhutch.org/scicomp-nexus/${CI_PROJECT_NAME}:${CI_COMMIT_BRANCH}
 
 deploy_preview:
   stage: deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && apt-get install -y libssh-dev python3-pip git
 
 RUN R -q -e 'install.packages(c("ellipsis"), repos="https://cran.rstudio.com/")'
 RUN R -q -e 'install.packages(c("shiny"), repos="https://cran.rstudio.com/")'
-RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard", "shinydashboardPlus", "ssh", "remotes", "markdown", "lubridate", "jsonlite", "dplyr", "DT", "glue", "httr", "purrr", "RColorBrewer", "rlang", "shinyBS", "shinyjs", "tidyverse", "uuid", "memoise", "rclipboard", "shinyvalidate", "shinylogs", "testhat"), repos="https://cran.r-project.org")'
+RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard", "shinydashboardPlus", "ssh", "remotes", "markdown", "lubridate", "jsonlite", "dplyr", "DT", "glue", "httr", "purrr", "RColorBrewer", "rlang", "shinyBS", "shinyjs", "tidyverse", "uuid", "memoise", "rclipboard", "shinyvalidate", "shinylogs", "testhat", "bsicons"), repos="https://cran.r-project.org")'
 
 RUN R -q -e "remotes::install_github('getwilds/proofr@v0.2')"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM fredhutch/r-shiny-server-base:4.3.2
 
-RUN apt-get update -y && apt-get install -y libssh-dev
+RUN apt-get update -y && apt-get install -y libssh-dev python3-pip git
 
 RUN R -q -e 'install.packages(c("ellipsis"), repos="https://cran.rstudio.com/")'
 RUN R -q -e 'install.packages(c("shiny"), repos="https://cran.rstudio.com/")'
@@ -9,6 +9,9 @@ RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard
 RUN R -q -e "remotes::install_github('getwilds/proofr@v0.2')"
 
 RUN R -q -e "remotes::install_github('getwilds/rcromwell@v3.2.5')"
+
+# python wdl2mermaid setup:
+RUN pip install git+https://github.com/chanzuckerberg/miniwdl-viz.git
 
 RUN rm -rf /srv/shiny-server/
 COPY app/ /srv/shiny-server/

--- a/app/server.R
+++ b/app/server.R
@@ -588,6 +588,11 @@ server <- function(input, output, session) {
     updateTabItems(session, "tabs", "wdl")
   })
 
+  ### go back to tracking tab from wdl tab
+  observeEvent(input$linkToTrackingTab, {
+    updateTabsetPanel(session, "tabs", "tracking")
+  })
+
   callDurationUpdate <- eventReactive(input$trackingUpdate,
     {
       stop_safe_loggedin_serverup(rv$url, rv$token, rv$own)

--- a/app/sidebar.R
+++ b/app/sidebar.R
@@ -23,6 +23,10 @@ menu_item_trouble <- menuItem("Troubleshoot",
   tabName = "troubleshoot", icon = icon("wrench"),
   badgeLabel = "troubleshoot", badgeColor = "red"
 )
+menu_item_wdl <- menuItem("WDL",
+  tabName = "wdl", icon = icon("wrench"),
+  badgeLabel = "wdl", badgeColor = "light-blue"
+)
 
 proofSidebar <- function() {
   sidebarMenu(
@@ -32,7 +36,8 @@ proofSidebar <- function() {
     menu_item_validate,
     menu_item_submit,
     menu_item_track,
-    menu_item_trouble
+    menu_item_trouble,
+    menu_item_wdl
   )
 }
 
@@ -43,6 +48,7 @@ nonProofSidebar <- function() {
     menu_item_validate,
     menu_item_submit,
     menu_item_track,
-    menu_item_trouble
+    menu_item_trouble,
+    menu_item_wdl
   )
 }

--- a/app/tab-tracking.R
+++ b/app/tab-tracking.R
@@ -84,6 +84,9 @@ tab_tracking <- tabItem(
     box(
       width = 6,
       title = "Workflow Options",
+      actionButton(inputId = "wdlview",
+        label = bsicons::bs_icon("search"),
+        class = "btn-sm"),
       DTOutput("workflowOpt")
     ),
     box(

--- a/app/tab-tracking.R
+++ b/app/tab-tracking.R
@@ -1,4 +1,5 @@
 source("ui_components.R")
+library(bsicons)
 
 tab_tracking <- tabItem(
   tabName = "tracking",

--- a/app/tab-wdl.R
+++ b/app/tab-wdl.R
@@ -1,6 +1,7 @@
 tab_wdl <- tabItem(
   tabName = "wdl",
   fluidPage(
+    actionButton("linkToTrackingTab", "Back to Track Jobs Tab"),
     uiOutput("mermaid_diagram")
   )
 )

--- a/app/tab-wdl.R
+++ b/app/tab-wdl.R
@@ -1,0 +1,6 @@
+tab_wdl <- tabItem(
+  tabName = "wdl",
+  fluidPage(
+    uiOutput("mermaid_diagram")
+  )
+)

--- a/app/ui.R
+++ b/app/ui.R
@@ -20,6 +20,7 @@ source("tab-validate.R")
 source("tab-submission.R")
 source("tab-tracking.R")
 source("tab-troubleshoot.R")
+source("tab-wdl.R")
 source("sidebar.R")
 
 ui <- dashboardPage(
@@ -43,6 +44,9 @@ ui <- dashboardPage(
     tags$script("document.title = 'PROOF';"),
     shinyjs::useShinyjs(),
     rclipboard::rclipboardSetup(),
+    tags$head(
+      tags$script(src = "https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js")
+    ),
     enter_to_click,
     tooltip_style,
     google_analytics,
@@ -52,7 +56,8 @@ ui <- dashboardPage(
       tab_validate,
       tab_submission,
       tab_tracking,
-      tab_troublehsoot
+      tab_troublehsoot,
+      tab_wdl
     )
   )
 )

--- a/app/utils.R
+++ b/app/utils.R
@@ -66,9 +66,28 @@ make_copybtn <- function(x, clip_prefix, tooltip) {
   )
 }
 
+make_wdlbtn <- function(workflow_id) {
+  as.character(
+    actionButton(
+      inputId = glue("wdlview_{workflow_id}"),
+      label = bsicons::bs_icon("search"),
+      class = "btn-sm",
+      onclick = 'Shiny.setInputValue(\"wdlview_btn\", this.id, {priority: \"event\"})'
+    )
+  )
+}
+
 abbreviate <- function(x, last = 100) {
   if (nchar(x) < 100) return(x)
   paste0(substring(x, 1, last), " ...")
+}
+
+wdl_to_file <- function(workflow_id, url, token) {
+  glob <- cromwell_glob(workflow_id, url = url, token = token)
+  wdl_str <- glob$submittedFiles$workflow
+  tfile <- tempfile(pattern = "wdlize_wdl", fileext = ".wdl")
+  cat(wdl_str, "\n", file = tfile)
+  return(tfile)
 }
 
 wdl2mermaid <- function(wdlFileName) {
@@ -81,4 +100,15 @@ wdl2mermaid <- function(wdlFileName) {
   ret <- readLines(outfile)
   unlink(outfile)
   paste(ret, collapse = "\n")
+}
+
+mermaid_container <- function(code) {
+  tags$div(
+    id = "mermaid-container",
+    tags$div(id = "mermaid-diagram", `class` = "mermaid", width = "auto", height = "auto", HTML(code)),
+    tags$script(HTML("
+      mermaid.initialize({ startOnLoad: true });
+      mermaid.init(undefined, '#mermaid-diagram');
+    "))
+  )
 }

--- a/app/utils.R
+++ b/app/utils.R
@@ -70,3 +70,15 @@ abbreviate <- function(x, last = 100) {
   if (nchar(x) < 100) return(x)
   paste0(substring(x, 1, last), " ...")
 }
+
+wdl2mermaid <- function(wdlFileName) {
+  outfile <- tempfile(pattern = "wdl2mermaid", fileext = ".mermaid")
+  system2(
+    "wdl_to_mermaid",
+    args = c(shQuote(wdlFileName), "--print-flowchart"),
+    stdout = outfile
+  )
+  ret <- readLines(outfile)
+  unlink(outfile)
+  paste(ret, collapse = "\n")
+}

--- a/app/utils.R
+++ b/app/utils.R
@@ -1,4 +1,5 @@
 library(memoise)
+library(bsicons)
 
 # coerce dates to PT from UTC
 as_pt <- function(x) {


### PR DESCRIPTION
I added a function to the end of utils.R called wdl2mermaid. It takes a filename of a wdl file and returns a character vector of length 1 containing a mermaid diagram. 

This also includes the infrastructure for installing https://github.com/chanzuckerberg/miniwdl-viz 

We still need functionality to display the mermaid diagram. 

There was a suggestion about adding this to rcromwell instead but I think it might be better to have it here because this is dockerized so it's easy to install the dependencies. I don't want R users to have to deal with an R package installing python stuff.

