### PR TITLE
Use cookies to store user login data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM fredhutch/r-shiny-server-base:4.3.2
 
-RUN apt-get update -y && apt-get install -y libssh-dev
+RUN apt-get update -y && apt-get install -y libssh-dev libmariadb-dev
 
 RUN R -q -e 'install.packages(c("ellipsis"), repos="https://cran.rstudio.com/")'
 RUN R -q -e 'install.packages(c("shiny"), repos="https://cran.rstudio.com/")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ RUN apt-get update -y && apt-get install -y libssh-dev
 
 RUN R -q -e 'install.packages(c("ellipsis"), repos="https://cran.rstudio.com/")'
 RUN R -q -e 'install.packages(c("shiny"), repos="https://cran.rstudio.com/")'
-RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard", "shinydashboardPlus", "ssh", "remotes", "markdown", "lubridate", "jsonlite", "dplyr", "DT", "glue", "httr", "purrr", "RColorBrewer", "rlang", "shinyBS", "shinyjs", "tidyverse", "uuid", "memoise", "rclipboard", "shinyvalidate", "shinylogs", "testhat"), repos="https://cran.r-project.org")'
+RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard", "shinydashboardPlus", "ssh", "remotes", "markdown", "lubridate", "jsonlite", "dplyr", "DT", "glue", "httr", "purrr", "RColorBrewer", "rlang", "shinyBS", "shinyjs", "tidyverse", "uuid", "memoise", "rclipboard", "shinyvalidate", "shinylogs", "testhat", "cookies"), repos="https://cran.r-project.org")'
 
 RUN R -q -e "remotes::install_github('getwilds/proofr@v0.2')"
 
 RUN R -q -e "remotes::install_github('getwilds/rcromwell@v3.2.1')"
+
+ADD .my.cnf /root/
 
 RUN rm -rf /srv/shiny-server/
 COPY app/ /srv/shiny-server/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && apt-get install -y libssh-dev
 
 RUN R -q -e 'install.packages(c("ellipsis"), repos="https://cran.rstudio.com/")'
 RUN R -q -e 'install.packages(c("shiny"), repos="https://cran.rstudio.com/")'
-RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard", "shinydashboardPlus", "ssh", "remotes", "markdown", "lubridate", "jsonlite", "dplyr", "DT", "glue", "httr", "purrr", "RColorBrewer", "rlang", "shinyBS", "shinyjs", "tidyverse", "uuid", "memoise", "rclipboard", "shinyvalidate", "shinylogs", "testhat", "cookies"), repos="https://cran.r-project.org")'
+RUN R -q -e 'install.packages(c("shinyFeedback", "shinyWidgets", "shinydashboard", "shinydashboardPlus", "ssh", "remotes", "markdown", "lubridate", "jsonlite", "dplyr", "DT", "glue", "httr", "purrr", "RColorBrewer", "rlang", "shinyBS", "shinyjs", "tidyverse", "uuid", "memoise", "rclipboard", "shinyvalidate", "shinylogs", "testhat", "cookies", "RMariaDB", "DBI"), repos="https://cran.r-project.org")'
 
 RUN R -q -e "remotes::install_github('getwilds/proofr@v0.2')"
 

--- a/app/cookies-db.R
+++ b/app/cookies-db.R
@@ -52,5 +52,5 @@ user_drop_from_db <- function(user, conn = make_db_con()) {
     DELETE from users
     WHERE user = {user}
   ", .con = conn)
-  dbSendQuery(conn, sql_delete)
+  dbGetQuery(conn, sql_delete)
 }

--- a/app/cookies-db.R
+++ b/app/cookies-db.R
@@ -31,13 +31,22 @@ user_from_db <- function(user, conn = make_db_con(), expiry = COOKIE_EXPIRY_DAYS
   dbReadTable(conn, "users") %>%
     as_tibble() %>%
     filter(
-      user == user,
+      # !! needed to get the value of the variable
+      user == !!user,
       login_time > now() - days(expiry)
     ) %>%
     arrange(desc(login_time))
 }
-user_to_db <- function(user, token, url, conn = make_db_con()) {
+user_to_db <- function(user, token, url, drop_existing = FALSE, conn = make_db_con()) {
   on.exit(dbDisconnect(conn))
+  # drop before inserting so we only have 1 row/user
+  if (drop_existing) {
+    # don't drop if user is empty
+    if (nzchar(user)) {
+      # don't disconnect from within drop fun
+      user_drop_from_db(user, disconnect = FALSE, conn = conn)
+    }
+  }
   tibble(
     user = user,
     proof_token = token,
@@ -46,11 +55,13 @@ user_to_db <- function(user, token, url, conn = make_db_con()) {
   ) %>%
     dbWriteTable(conn, "users", ., append = TRUE)
 }
-user_drop_from_db <- function(user, conn = make_db_con()) {
-  on.exit(dbDisconnect(conn))
+user_drop_from_db <- function(user, disconnect = TRUE, conn = make_db_con()) {
+  if (disconnect) {
+    on.exit(dbDisconnect(conn))
+  }
   sql_delete <- glue::glue_sql("
     DELETE from users
     WHERE user = {user}
   ", .con = conn)
-  dbGetQuery(conn, sql_delete)
+  dbExecute(conn, sql_delete)
 }

--- a/app/cookies-db.R
+++ b/app/cookies-db.R
@@ -1,7 +1,7 @@
 library(RMariaDB)
 library(DBI)
 
-COOKIE_EXPIRY_DAYS <- 1
+COOKIE_EXPIRY_DAYS <- 14
 
 to_base64 <- function(x) {
   base64enc::base64encode(charToRaw(x))

--- a/app/cookies-db.R
+++ b/app/cookies-db.R
@@ -1,0 +1,56 @@
+library(RMariaDB)
+library(DBI)
+
+COOKIE_EXPIRY_DAYS <- 1
+
+to_base64 <- function(x) {
+  base64enc::base64encode(charToRaw(x))
+}
+from_base64 <- function(x) {
+  rawToChar(base64enc::base64decode(x))
+}
+
+db <- dbConnect(RMariaDB::MariaDB(), group = "shinycromwell")
+if (!dbExistsTable(db, "users")) {
+  db_columns <- c(
+    user = "TEXT",
+    proof_token = "TEXT",
+    cromwell_url = "TEXT",
+    login_time = "TEXT"
+  )
+  dbCreateTable(db, "users", db_columns)
+}
+dbDisconnect(db)
+
+make_db_con <- function() {
+  dbConnect(RMariaDB::MariaDB(), group = "shinycromwell")
+}
+
+user_from_db <- function(user, conn = make_db_con(), expiry = COOKIE_EXPIRY_DAYS) {
+  on.exit(dbDisconnect(conn))
+  dbReadTable(conn, "users") %>%
+    as_tibble() %>%
+    filter(
+      user == user,
+      login_time > now() - days(expiry)
+    ) %>%
+    arrange(desc(login_time))
+}
+user_to_db <- function(user, token, url, conn = make_db_con()) {
+  on.exit(dbDisconnect(conn))
+  tibble(
+    user = user,
+    proof_token = token,
+    cromwell_url = url,
+    login_time = as.character(now())
+  ) %>%
+    dbWriteTable(conn, "users", ., append = TRUE)
+}
+user_drop_from_db <- function(user, conn = make_db_con()) {
+  on.exit(dbDisconnect(conn))
+  sql_delete <- glue::glue_sql("
+    DELETE from users
+    WHERE user = {user}
+  ", .con = conn)
+  dbSendQuery(conn, sql_delete)
+}

--- a/app/server.R
+++ b/app/server.R
@@ -90,14 +90,15 @@ server <- function(input, output, session) {
 
   observeEvent(cookies::get_cookie("user"), {
     rv$user <- cookies::get_cookie("user")
-    print(rv$user)
-    user_df <- user_from_db(rv$user) %>% top_n(1)
-    if (nrow(user_df)) {
-      rv$url <- from_base64(user_df$cromwell_url)
-      rv$token <- from_base64(user_df$proof_token)
-    }
-    if (is.null(input$username)) {
-      output$userName <- renderText({ rv$user })
+    # print(rv$user)
+    # print(nchar(rv$user))
+    if (!is.null(rv$user)) {
+      user_df <- user_from_db(rv$user) %>% top_n(1)
+      if (nrow(user_df)) {
+        #print(user_df)
+        rv$url <- from_base64(user_df$cromwell_url)
+        rv$token <- from_base64(user_df$proof_token)
+      }
     }
   })
 

--- a/app/ui.R
+++ b/app/ui.R
@@ -13,6 +13,8 @@ library(lubridate)
 
 library(rclipboard)
 
+library(cookies)
+
 source("ui_components.R")
 source("tab-welcome.R")
 source("tab-servers.R")
@@ -22,37 +24,39 @@ source("tab-tracking.R")
 source("tab-troubleshoot.R")
 source("sidebar.R")
 
-ui <- dashboardPage(
-  skin = "black",
-  dashboardHeader(
-    title = tagList(
-      span(class = "logo-lg", h4(HTML("Fred Hutch<br> PROOF Dashboard"))),
-      img(src = "fred-hutch.svg")
+ui <- cookies::add_cookie_handlers(
+  dashboardPage(
+    skin = "black",
+    dashboardHeader(
+      title = tagList(
+        span(class = "logo-lg", h4(HTML("Fred Hutch<br> PROOF Dashboard"))),
+        img(src = "fred-hutch.svg")
+      ),
+      dropdown_user_name,
+      dropdown_own_cromwell,
+      dropdown_loginout,
+      dropdown_help,
+      dropdown_src
     ),
-    dropdown_user_name,
-    dropdown_own_cromwell,
-    dropdown_loginout,
-    dropdown_help,
-    dropdown_src
-  ),
-  dashboardSidebar(
-    sidebarMenuOutput("uiSideBar")
-  ),
-  dashboardBody(
-    tags$head(tags$title("PROOF")),
-    tags$script("document.title = 'PROOF';"),
-    shinyjs::useShinyjs(),
-    rclipboard::rclipboardSetup(),
-    enter_to_click,
-    tooltip_style,
-    google_analytics,
-    tabItems(
-      tab_welcome,
-      tab_servers,
-      tab_validate,
-      tab_submission,
-      tab_tracking,
-      tab_troublehsoot
+    dashboardSidebar(
+      sidebarMenuOutput("uiSideBar")
+    ),
+    dashboardBody(
+      tags$head(tags$title("PROOF")),
+      tags$script("document.title = 'PROOF';"),
+      shinyjs::useShinyjs(),
+      rclipboard::rclipboardSetup(),
+      enter_to_click,
+      tooltip_style,
+      google_analytics,
+      tabItems(
+        tab_welcome,
+        tab_servers,
+        tab_validate,
+        tab_submission,
+        tab_tracking,
+        tab_troublehsoot
+      )
     )
   )
 )


### PR DESCRIPTION
fix #118 

This adds cookies for just username and password, so that those data are not lost when the app gets refreshed, and/or when the user opens up the app in another (non-private) tab in the same browser. 

This approach persists the data in a Mariadb database, which is more database than we need, but when it doesn't cost extra it seems fine. And we may want to persist other data to the database in the future anyway

This will be a nice quality of life improvement for working on the app code as well because the session login won't be lost when the app refreshes on each code change 😄 

also @sitapriyamoorthi review please and thx

## to run it

You can't see this deployed because we only have that setup for main and dev, but you can run it locally with a new make command, see https://github.com/FredHutch/shiny-cromwell/tree/dev?tab=readme-ov-file#run-a-feature-branch-locally 

After getting login creds from Dan, run `make branch=cookie-cutter run_branch` from this repo locally and it should pull up this branch on http://0.0.0.0:3838