### PR TITLE
Filtering workflow name improvements and addition of labels filtering

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -753,9 +753,9 @@ server <- function(input, output, session) {
   })
 
   # Data for cards out of workflowUpdate data
-  output$workflows_cards <- renderUI({
+  workflowCards <- reactive({
     dflst <- apply(workflowUpdate(), 1, as.list)
-    dat <- lapply(dflst, function(w) {
+    lapply(dflst, function(w) {
       list(
        data = w,
        card = card(
@@ -805,6 +805,10 @@ server <- function(input, output, session) {
         )
       )
     })
+  })
+
+  workflowCardsFiltered <- reactive({
+    dat <- workflowCards()
     # Filter by date
     dat <- Filter(\(w) {
       parse_date_tz(w$data$submission) >= parse_date_tz(paste(input$runs_date[1], "00:00:00")) &&
@@ -817,20 +821,29 @@ server <- function(input, output, session) {
       }, dat)
     }
     # Filter by workflow name
-    if (nzchar(input$workName)) {
+    print(input$workName)
+    if (!is.null(input$workName)) {
       dat <- Filter(\(w) {
-        w$data$workflow_name == input$workName
+        w$data$workflow_name %in% input$workName
       }, dat)
     }
-    # return cards
-    purrr::map(dat, "card")
+    # Filter by labels
+    print(input$labelName)
+    if (!is.null(input$labelName)) {
+      dat <- Filter(\(w) {
+        w$data$Label %in% input$labelName ||
+          w$data$secondaryLabel %in% input$labelName
+      }, dat)
+    }
+    return(dat)
   })
 
-  observeEvent(input$trackingUpdate, {
-  # observeEvent(input$proof, {
-    # wnames <- as.character(workflowUpdate()$workflow_name) |>
-    #   purrr::discard(is.na) |>
-    #   unique()
+  output$workflows_cards <- renderUI({
+    purrr::map(workflowCardsFiltered(), "card")
+  })
+
+  # Tracking page filters: Workflow name - initial
+  observeEvent(input$proof, {
     stop_safe_loggedin_serverup(rv$url, rv$token, rv$own)
     jobs <- cromwell_jobs(
       days = 60,
@@ -846,6 +859,20 @@ server <- function(input, output, session) {
       inputId = "workName",
       label = "Workflow name",
       choices = wnames
+    )
+  })
+
+
+  # Tracking page filters: Workflow labels - initial
+  observeEvent(input$proof, {
+    df <- workflowUpdate()
+    labels <- unique(c(df$Label, df$secondaryLabel))
+    print(labels)
+    updateSelectInput(
+      session = session,
+      inputId = "labelName",
+      label = "Label name",
+      choices = labels
     )
   })
 

--- a/app/server.R
+++ b/app/server.R
@@ -826,6 +826,29 @@ server <- function(input, output, session) {
     purrr::map(dat, "card")
   })
 
+  observeEvent(input$trackingUpdate, {
+  # observeEvent(input$proof, {
+    # wnames <- as.character(workflowUpdate()$workflow_name) |>
+    #   purrr::discard(is.na) |>
+    #   unique()
+    stop_safe_loggedin_serverup(rv$url, rv$token, rv$own)
+    jobs <- cromwell_jobs(
+      days = 60,
+      url = rv$url,
+      token = rv$token
+    )
+    wnames <- as.character(jobs$workflow_name) |>
+      purrr::discard(is.na) |>
+      unique()
+    print(wnames)
+    updateSelectInput(
+      session = session,
+      inputId = "workName",
+      label = "Workflow name",
+      choices = wnames
+    )
+  })
+
   ## Abort a workflow with the abort button on each card
   observeEvent(input$abortWorkflow, {
     validate_workflowid(isolate(input$selectedWorkflowId))

--- a/app/tab-tracking.R
+++ b/app/tab-tracking.R
@@ -5,8 +5,6 @@ library(glue)
 library(bslib)
 
 sidebar_tracking <- sidebar(
-  # numericInput("daysToShow", "Days of History to Display:",
-  #     min = 1, max = NA, value = 1, step = 1),
   actionButton(
     inputId = "trackingUpdate",
     label = "Refresh data",
@@ -20,10 +18,16 @@ sidebar_tracking <- sidebar(
   ),
   hr(),
   selectInput(
-    inputId = "workName", 
+    inputId = "workName",
     label = "Workflow name",
     choices = "",
-    multiple = FALSE
+    multiple = TRUE
+  ),
+  selectInput(
+    inputId = "labelName",
+    label = "Label name",
+    choices = "",
+    multiple = TRUE
   ),
   selectInput(
     inputId = "workStatus",
@@ -36,7 +40,7 @@ sidebar_tracking <- sidebar(
     multiple = TRUE,
   ),
   dateRangeInput(
-    inputId = "runs_date", 
+    inputId = "runs_date",
     label = "Date Range",
     start = "2024-01-01",
     end = lubridate::today(),
@@ -53,15 +57,9 @@ sidebar_tracking <- sidebar(
     multiple = FALSE
   ),
   actionButton("resetTrackingFilters", "Reset all filters", class = "btn-sm")
-  # actionButton(
-  #   inputId = "trackingUpdate",
-  #   label = "Refresh data",
-  #   icon = icon("refresh")
-  # )
 )
 
 card_tracking_intro <- card(
-  # max_height = "100px",
   fill = FALSE,
   card_header(
     h3("Track your Workflows"),
@@ -103,13 +101,7 @@ tab_tracking <- page_sidebar(
   navset_card_underline(
     nav_panel(
       title = "Workflow Runs",
-      # dateRangeInput("runs_date",
-      #   label = "Date Range",
-      #   start = "2024-01-01",
-      #   end = "2024-08-30"
-      # ),
       workflow_cards
-      # card_workflow_runs
     ),
     nav_panel(
       title = "Workflow Timing",

--- a/app/tab-tracking.R
+++ b/app/tab-tracking.R
@@ -22,7 +22,6 @@ sidebar_tracking <- sidebar(
   selectInput(
     inputId = "workName", 
     label = "Workflow name",
-    value = "",
     choices = "",
     multiple = FALSE
   ),

--- a/app/tab-tracking.R
+++ b/app/tab-tracking.R
@@ -19,11 +19,12 @@ sidebar_tracking <- sidebar(
     placement = "bottom"
   ),
   hr(),
-  textInput(
+  selectInput(
     inputId = "workName", 
     label = "Workflow name",
     value = "",
-    placeholder = "myCustomWorkflow",
+    choices = "",
+    multiple = FALSE
   ),
   selectInput(
     inputId = "workStatus",


### PR DESCRIPTION
fix #112 

- unrelated, but cleaned out a bit of commented out code in tab-tracking.R
- added input field for labels (combines primary and secondary labels) 
- both name and label inputs are populated by the data itself, and as you type you get the matching names or labels. does this work good enough? not good enough?
- The big bummer about this setup (And this was the case before this PR too) is that as filters are applied the filters themselves do not update. the cards update just fine, its just that the filters aren't changed accordingly when another filter is changed, so a naive user might get confused. an attempt below in a comment that didn't work with notes


you should be able to use `make branch=workflow-name-select run_branch` 