### PR TITLE
Point dockerized shiny app at different instances of the API

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,10 +54,6 @@ test:
 
 deploy_review_image:
   stage: deploy
-  except:
-    refs:
-      - main
-      - dev
   script:
     - docker tag sc-registry.fredhutch.org/shiny-cromwell:test nexus-registry.fredhutch.org/scicomp-nexus/${CI_PROJECT_NAME}:${CI_COMMIT_BRANCH}
     - docker push nexus-registry.fredhutch.org/scicomp-nexus/${CI_PROJECT_NAME}:${CI_COMMIT_BRANCH}

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,19 @@ run_branch:
 	docker pull nexus-registry.fredhutch.org/scicomp-nexus/shiny-cromwell:$(branch)
 	docker run --rm -it -p 3838:3838 nexus-registry.fredhutch.org/scicomp-nexus/shiny-cromwell:$(branch)
 
+# point the shiny app at the dev API
+# use: `make branch=inputs-viewer run_branch`
+run_branch_dev_api:
+	docker pull nexus-registry.fredhutch.org/scicomp-nexus/shiny-cromwell:$(branch)
+	docker run -e PROOF_API_BASE_URL=https://proof-api-dev.fredhutch.org --rm -it -p 3838:3838 nexus-registry.fredhutch.org/scicomp-nexus/shiny-cromwell:$(branch)
+
+# point the shiny app at a custom API instance
+# use: `make branch=inputs-viewer url=http://gizmo666:2112 run_branch_custom_api`
+run_branch_custom_api:
+	docker pull nexus-registry.fredhutch.org/scicomp-nexus/shiny-cromwell:$(branch)
+	docker run -e PROOF_API_BASE_URL=$(url) --rm -it -p 3838:3838 nexus-registry.fredhutch.org/scicomp-nexus/shiny-cromwell:$(branch)
+
+
 # use: `make style_file FILE=stuff.R`
 # accepts 1 file only
 style_file:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ run_branch:
 	docker run --rm -it -p 3838:3838 nexus-registry.fredhutch.org/scicomp-nexus/shiny-cromwell:$(branch)
 
 # point the shiny app at the dev API
-# use: `make branch=inputs-viewer run_branch`
+# use: `make branch=inputs-viewer run_branch_dev_api`
 run_branch_dev_api:
 	docker pull nexus-registry.fredhutch.org/scicomp-nexus/shiny-cromwell:$(branch)
 	docker run -e PROOF_API_BASE_URL=https://proof-api-dev.fredhutch.org --rm -it -p 3838:3838 nexus-registry.fredhutch.org/scicomp-nexus/shiny-cromwell:$(branch)


### PR DESCRIPTION
This enables testers to run the shiny app and have it point to different versions of the PROOF API.

Until now, it was a bit of a pain to test changes to the PROOF API that were in dev - you couldn't do it with the shiny app. You had to use proofr (being sure to set the `PROOF_API_BASE_URL` to `https://proof-api-dev.fredhutch.org`) or the swagger UI at https://proof-api-dev.fredhutch.org . 

This builds on the previously added ability for testers to run different versions of the shiny app locally using Docker:

```
make branch=branch_name run_branch
```

Assuming `branch_name` is a valid branch of this repo, which has built successfully, this command will run the Docker image of that branch, which you can then access at http://localhost:3838 .

The present change enables two new Makefile targets:

```
make branch=branch_name run_branch_dev_api
```

That will run the shiny app and it will point at the dev version of the API.

For developers of the API (mostly me), you can also do this:

```
make branch=branch_name url=http://gizmo666:2112 run_branch_custom_api
```

Assuming you had an instance of the PROOF API at that URL, this would connect to it.

## If the app goes grey

If you do all this, you may see the app go grey, and the following message in the terminal:

```
Warning: Error in req_perform: HTTP 401 Unauthorized.
• Additional context: No user for this token
```

If that happens, delete the cookies for the site. Basically, the app is getting confused because the dev version of the app uses different tokens than the production version. Deleting cookies and logging in again will solve this (and you should do this again when you switch back to using the prod version of the app, or running it locally). 

Deleting cookies for a specific site works differently in each browser, but in Firefox you can click the lock to the left of the URL bar and then click `Clear cookies and site data...`. 


![image](https://github.com/user-attachments/assets/b9371005-cf97-4bc5-a9dd-ef194ee5b166)

## A note about branches

The above examples use a non-existent branch name called `branch_name`. In reality you would pick the branch of the app you want to test. If you are not testing anything specific in the shiny app (just functionality in the API) then you can choose the `main` or `dev` branch (or you will be able to do that, once this PR is merged into those branches).


