### PR TITLE
change workflow timing plot logic

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -830,10 +830,16 @@ server <- function(input, output, session) {
   )
 
   output$workflowDuration <- renderPlot({
-    if ("workflow_name" %in% colnames(workflowUpdate())) {
-      print("inside workflowDuration ...")
+    print("inside workflowDuration ...")
+    df <- workflowUpdate()
+    if (NROW(df) == 1 && NCOL(df) == 1) {
+      print("inside workflowDuration (returning blank plot) ...")
+      ggplot() +
+        geom_blank()
+    } else if ("workflow_name" %in% colnames(df)) {
+      print("inside workflowDuration (using workflow_name) ...")
       ggplot(
-        workflowUpdate(),
+        df,
         aes(x = as.factor(workflow_name), y = as.numeric(workflowDuration))
       ) +
         geom_point(aes(color = status), width = 0.05, size = 4) +
@@ -844,8 +850,18 @@ server <- function(input, output, session) {
         ylab("Workflow Duration (mins)") +
         xlab("Workflow Name")
     } else {
-      ggplot() +
-        geom_blank()
+      print("inside workflowDuration (using workflow_id) ...")
+      ggplot(
+        df,
+        aes(x = as.factor(workflow_id), y = as.numeric(workflowDuration))
+      ) +
+        geom_point(aes(color = status), width = 0.05, size = 4) +
+        coord_flip() +
+        theme_minimal() +
+        theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
+        scale_color_manual(values = myCols) +
+        ylab("Workflow Duration (mins)") +
+        xlab("Workflow ID")
     }
   })
 


### PR DESCRIPTION
- print empty plot if empty dataframe (single row, single column with a single NA)
- print workflow names on flipped x-axis if available
- print workflow ids on flipped x-asis if workflow names not available

fix #211 

The plots using workflow id are a bit silly because there's no duplicate workflows as there are when using workflow names so each workflow uses another row in the plot, And the workflow Ids are UUIDs so are quite long. BUT this is just a stop gap to prevent errors, so I think okay, yes?

<img width="1454" height="488" alt="Screenshot 2025-10-28 at 12 06 15 PM" src="https://github.com/user-attachments/assets/e5eb7d15-9dec-4b01-b7b7-6edac63509cc" />

<img width="1449" height="481" alt="Screenshot 2025-10-28 at 12 06 27 PM" src="https://github.com/user-attachments/assets/37f0d427-459d-4109-b678-a39da454f904" />


Note the special checking for an "empty workflowUpdate" where its empty if it looks like

```r
# A tibble: 1 × 1
  workflow_id
  <lgl>
1 NA
```


So we check for a single column and a single row