### PR TITLE
use uv for build env

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,26 +64,6 @@ test:
     curl -sI http://shiny-cromwell:3838 | head -1 | grep -q "200 OK"
     docker run -w /srv/shiny-server --rm sc-registry.fredhutch.org/shiny-cromwell:test R -q -e 'testthat::test_dir("tests")'
 
-deploy_review_image:
-  stage: deploy
-  except:
-    refs:
-      - main
-      - dev
-  script:
-    - docker tag sc-registry.fredhutch.org/shiny-cromwell:test nexus-registry.fredhutch.org/scicomp-nexus/${CI_PROJECT_NAME}:${CI_COMMIT_BRANCH}
-    - docker push nexus-registry.fredhutch.org/scicomp-nexus/${CI_PROJECT_NAME}:${CI_COMMIT_BRANCH}
-
-deploy_review_image:
-  stage: deploy
-  except:
-    refs:
-      - main
-      - dev
-  script:
-    - docker tag sc-registry.fredhutch.org/shiny-cromwell:test nexus-registry.fredhutch.org/scicomp-nexus/${CI_PROJECT_NAME}:${BRANCH_OR_TAG}
-    - docker push nexus-registry.fredhutch.org/scicomp-nexus/${CI_PROJECT_NAME}:${BRANCH_OR_TAG}
-
 deploy_preview:
   stage: deploy
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,11 @@ variables:
 before_script:
   - apk update
   - apk --no-cache add py3-pip python3 curl
-  - python3 -m venv $HOME/.venv
-  - export PATH=$HOME/.venv/bin:$PATH
-  - pip3 install pyyaml
+  - curl -LsSf https://astral.sh/uv/install.sh | sh
+  - export PATH=$HOME/.local/bin:$PATH
+  - uv venv --python 3.12
+  - source .venv/bin/activate
+  - uv pip install pyyaml  
   - curl -O https://raw.githubusercontent.com/FredHutch/swarm-build-helper/main/build_helper.py
   # below is from https://stackoverflow.com/a/65810302/470769
   - mkdir -p $HOME/.docker


### PR DESCRIPTION
We had an incident with the docker swarm and apps need to be redeployed with a slight change (we use the docker:dind image for CI/CD and it has updated since the last time we needed to pull it).
So in order for the proof web app to come back up, this needs to be merged.